### PR TITLE
Adición de Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,69 @@
+# Historial de comandos de R
+.Rhistory
+
+# Archivos temporales de R
+.RData
+
+# Archivos de configuración de R
+.Ruserdata
+
+# Archivos de entorno de R
+.Renviron
+
+# Directorios de R lib (paquetes instalados localmente)
+rlib/
+
+# Archivos de proyecto de RStudio
+.Rproj.user/
+.Rproj
+
+# Archivos temporales de RStudio
+.rs.history
+
+# Archivos de suspensión de RStudio
+.rs.RData
+
+# Archivos temporales generados por la compilación
+*.tar.gz
+*.Rcheck/
+*.Rproj.user/
+
+# Omitir archivos de paquetes si se gestionan en un repositorio separado
+PACKAGES
+
+# Archivos generados por roxygen2
+man/
+NAMESPACE
+
+# Archivos de salida de Sweave
+*.snm
+*.out
+*.nav
+*.log
+*.aux
+*.toc
+*.blg
+*.bbl
+*.synctex.gz
+*.synctex(busy)
+
+# Archivos de salida de knitr y R Markdown
+*.md
+*.html
+*.pdf
+*.docx
+*.rtf
+
+# Cache de knitr
+/cache/
+figure/
+
+# Otros archivos y directorios a ignorar
+.DS_Store
+Thumbs.db
+
+# Archivos de configuración de paquetes específicos
+.Rproj.user/
+.Rhistory
+.RData
+.Ruserdata


### PR DESCRIPTION
### **Adición de Gitignore**
- **`.Rhistory`**: Ignora el historial de comandos de R.
- **`.RData`**: Excluye archivos temporales que contienen el estado del espacio de trabajo de R.
- **`.Ruserdata`**: Ignora archivos de configuración específicos del usuario de R.
- **`.Renviron`**: Omite archivos de entorno de R que contienen variables de entorno definidas por el usuario.
- **`rlib/`**: Excluye directorios que contienen paquetes de R instalados localmente.
- **`.Rproj.user/`**, **`.Rproj`**: Ignora archivos y directorios específicos del proyecto de RStudio.
- **`.rs.history`**, **`.rs.RData`**: Omite archivos temporales y de suspensión de RStudio.
- **`*.tar.gz`, `*.Rcheck/`, `*.Rproj.user/`**: Excluye archivos generados por la compilación y la verificación de paquetes.
- **`PACKAGES`**: Ignora archivos de paquetes si se gestionan en un repositorio separado.
- **`man/`, `NAMESPACE`**: Omite archivos generados por roxygen2 para documentación.
- **Archivos de salida de Sweave y knitr**: Ignora archivos `.snm`, `.out`, `.nav`, `.log`, `.aux`, `.toc`, `.blg`, `.bbl`, `.synctex.gz`, `.synctex(busy)`, además de los archivos de salida como `.md`, `.html`, `.pdf`, `.docx`, `.rtf`.
- **Cache de knitr**: Excluye directorios `/cache/` y `figure/` utilizados para guardar cachés y figuras generadas.
- **Otros archivos y directorios**: Ignora archivos comunes del sistema como `.DS_Store` y `Thumbs.db`.
- **Archivos de configuración de paquetes específicos**: Omite configuraciones de usuario y archivos temporales específicos de R y RStudio nuevamente listados al final para énfasis.
